### PR TITLE
some changes to code examples to make them more complete

### DIFF
--- a/src/02-server_routes_endpoints.md
+++ b/src/02-server_routes_endpoints.md
@@ -6,20 +6,23 @@ When a `Server` is started it will handle incoming `Request`s by matching their 
 
 ## Set up a Server
 
-A Tide `Server` can simply be constructed with its `new()` constructor.
+A basic Tide `Server` is constructed with `tide::new()`.
 ```rust
-use tide::prelude::*;
-let mut = Server::new();
-```
-or even shorter by using the `new()` convenience method provided in the `tide` namespace
-```rust
-let mut server = tide::new();
+#[async_std::main]
+async fn main() -> tide::Result<()> {
+    let server = tide::new();
+    Ok(())
+}
 ```
 
 The server can then be started using the asynchronous `listen` method.
 ```rust
-let mut server = tide::new();
-server.listen("127.0.0.1:8080").await?;
+#[async_std::main]
+async fn main() -> tide::Result<()> {
+    let server = tide::new();
+    server.listen("127.0.0.1:8080").await?;
+    Ok(())
+}
 ```
 
 While this is the simpelest Tide application that you can build, it is not very useful. It will return a 404 HTTP response to any request. To be able to return anything useful we will need to handle requests using one or more `Endpoint`s
@@ -29,32 +32,45 @@ While this is the simpelest Tide application that you can build, it is not very 
 To make the `Server` return anything other than an HTTP 404 reply we need to tell it how to react to requests. We do this by adding one or more Endpoints;
 
 ```rust
-server.at("*").get(|_req| async { Ok("Hello, world!") });
+#[async_std::main]
+async fn main() -> tide::Result<()> {
+    let mut server = tide::new();
+    server.at("*").get(|_| async { Ok("Hello, world!") });
+    server.listen("127.0.0.1:8080").await?;
+    Ok(())
+}
 ```
 
 We use the `at` method to specify the route to the endpoint. We will talk about routes later. For now we'll just use the `"*"` wildcard route that matches anything we throw at it. For this example we will add an async closure as the `Endpoint`. Tide expects something that implements the `Endpoint` trait here. But this closure will work because Tide implements the `Endpoint` trait for certain async functions with a signature that looks like this;
 ```rust
-async fn endpoint(request: Request) -> Result<impl Into<Response>>
+async fn endpoint(request: tide::Request) -> tide::Result<impl Into<Response>>
 ```
 
-In this case `Into<Response>` is implemented for `&str` so our closure is a valid Endpoint. Because `Into<Response>` is implemented for several other types you can quickly set up endpoints. For example the next endpoint uses the `json!` macro from the `serde_json` crate to return a `serde_json::Value`.
+In this case `Into<Response>` is implemented for `&str` so our closure is a valid Endpoint. Because `Into<Response>` is implemented for several other types you can quickly set up endpoints. For example the next endpoint uses the `json!` macro provided by `use tide::prelude::*` to return a `serde_json::Value`.
 
 ```rust
-server.at("*").get(|req| async {
-    Ok(json!({
-        "meta": { "count": 2 },
-        "animals": [
-            { "type": "cat", "name": "chashu" },
-            { "type": "cat", "name": "nori" }
-        ]
-    }))
-})
+use tide::prelude::*;
+#[async_std::main]
+async fn main() -> tide::Result<()> {
+    let mut server = tide::new();
+    server.at("*").get(|_| async {
+        Ok(json!({
+            "meta": { "count": 2 },
+            "animals": [
+                { "type": "cat", "name": "chashu" },
+                { "type": "cat", "name": "nori" }
+            ]
+        }))
+    });
+    server.listen("127.0.0.1:8080").await?;
+    Ok(())
+}
 ```
 
 Returning quick string or json results is nice for getting a working endpoint quickly. But for more control a full `Response` struct can be returned.
 
 ```rust
-server.at("*").get(|req| async {
+server.at("*").get(|_| async {
     Ok(Response::new(StatusCode::Ok).set_body("Hello world".into()))
 });
 ```
@@ -65,16 +81,22 @@ More than one endpoint can be added by chaining methods. For example if we want 
 
 ```rust
 server.at("*")
-    .get(|_req| async { Ok("Hello, world!") })
-    .delete(|_req| async { Ok("Goodbye, cruel world!") });
+    .get(|_| async { Ok("Hello, world!") })
+    .delete(|_| async { Ok("Goodbye, cruel world!") });
 ```
 
 Eventually, especially when our endpoint methods grow a bit, the route definitions will get a crowded. We could move our endpoint implementations to their own functions;
 
 ```rust
-server.at("/").get(endpoint);
+#[async_std::main]
+async fn main() -> tide::Result<()> {
+    let mut server = tide::new();
+    server.at("/").get(endpoint);
+    server.listen("127.0.0.1:8080").await?;
+    Ok(())
+}
 
-async fn endpoint(_req: tide::Request) -> Result<Response> {
+async fn endpoint(_req: tide::Request<()>) -> Result<Response> {
     Ok(Response::new(StatusCode::Ok).set_body("Hello world".into()))
 }
 ```


### PR DESCRIPTION
additionally:
* I removed reference to Server::new(), since we don't actually want people using that.  tide::new() or tide::with_state() are the primary entrypoints
* I tried to make examples compile if they're copied and pasted in their entirety, since it might not be clear how to combine several different lines from different snippets.  Hopefully we'll be able to have rust check that they compile in CI for the book. I think the goal should be to include at least one fully compilable example for each new "type of thing" we introduce, to show where it goes. I think it's ok to be a little overly verbose initially, part of teaching is repetition