### PR TITLE
rename ci.yml action to publish.yml and dont run on pull_request

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,6 @@ name: Publish github.io
 
 on:
   push:
-  pull_request:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The github action to publish the mdbook was also run for pr's. This failed.
In the future we should have a separate gh-action to test if the mdbook is valid and optionally run the code examples. For now I disabled publishing