### PR TITLE
add test for example code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Build the book, test the examples
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_book:
+    name: Build book
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.2'
+
+      - run: mdbook build
+
+  test_examples:
+    name: Test example code
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path examples/Cargo.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --manifest-path examples/Cargo.toml -- --check
+
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+  "ch01-02-example",
+]

--- a/examples/ch01-02-example/Cargo.toml
+++ b/examples/ch01-02-example/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "example"
+version = "0.1.0"
+authors = ["Mendelt Siebenga <msiebenga@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+async-std = { version = "1.6.5", features = ["attributes"] }
+serde = {version = "1.0.116", features = ["derive"]}
+tide = "0.14.0"

--- a/examples/ch01-02-example/src/main.rs
+++ b/examples/ch01-02-example/src/main.rs
@@ -1,0 +1,23 @@
+// ANCHOR: example
+use tide::Request;
+use tide::prelude::*;
+
+#[derive(Debug, Deserialize)]
+struct Animal {
+    name: String,
+    legs: u8,
+}
+
+#[async_std::main]
+async fn main() -> tide::Result<()> {
+    let mut app = tide::new();
+    app.at("/orders/shoes").post(order_shoes);
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
+}
+
+async fn order_shoes(mut req: Request<()>) -> tide::Result {
+    let Animal { name, legs } = req.body_json().await?;
+    Ok(format!("Hello, {}! I've put in an order for {} shoes", name, legs).into())
+}
+// ANCHOR END: example

--- a/examples/ch01-02-example/src/main.rs
+++ b/examples/ch01-02-example/src/main.rs
@@ -1,6 +1,6 @@
 // ANCHOR: example
-use tide::Request;
 use tide::prelude::*;
+use tide::Request;
 
 #[derive(Debug, Deserialize)]
 struct Animal {

--- a/src/01-introduction/02-example.md
+++ b/src/01-introduction/02-example.md
@@ -4,27 +4,7 @@ Create an HTTP server that receives a JSON body, validates it, and responds
 with a confirmation message.
 
 ```rust
-use tide::Request;
-use tide::prelude::*;
-
-#[derive(Debug, Deserialize)]
-struct Animal {
-    name: String,
-    legs: u8,
-}
-
-#[async_std::main]
-async fn main() -> tide::Result<()> {
-    let mut app = tide::new();
-    app.at("/orders/shoes").post(order_shoes);
-    app.listen("127.0.0.1:8080").await?;
-    Ok(())
-}
-
-async fn order_shoes(mut req: Request<()>) -> tide::Result {
-    let Animal { name, legs } = req.body_json().await?;
-    Ok(format!("Hello, {}! I've put in an order for {} shoes", name, legs).into())
-}
+{{#include ../../examples/ch01-02-example/src/main.rs:example}}
 ```
 
 ```sh


### PR DESCRIPTION
I moved a piece of example code out of the documentation and into a separate project that can now be tested using cargo. This is a bit more involved than writing examples the inline but has a couple of advantages so I'd like feedback on this;

Pros:
- Testing is easy
- We can write examples as one piece of code and use snippets as examples in the book (you can name snippets by with comments or you can include snippets by line number) This makes it easy to gradually introduce an example and, at the end, show all of the code.
- We can use all of cargo for testing, cargo fmt, clippy etc.

Cons:
- Maintaining code examples this way is more work.