### PR TITLE
Correct function name, add `no_run` for code, and add chinese book

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Tide book
 This repository contains the source for the [Tide Book], the book is written in the `markdown` format and is built using [mdbook].
 
+Languages:
+- [English][Tide Book]
 - [简体中文](https://github.com/zzy/tide-zh-cn), [在线阅读](https://tide.budshome.com)
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Tide book
 This repository contains the source for the [Tide Book], the book is written in the `markdown` format and is built using [mdbook].
 
+- [简体中文](https://github.com/zzy/tide-zh-cn), [在线阅读](https://tide.budshome.com)
+
 ## Development
 The documentation can be edited using any text editor. Most commonly used editors support syntax highlighting for the `markdown` format. To view your changes you can install the [mdbook] tool locally, assuming you already have a working `Rust` setup;
 ```console

--- a/examples/ch01-02-example/src/main.rs
+++ b/examples/ch01-02-example/src/main.rs
@@ -23,4 +23,4 @@ async fn order_shoes(mut req: Request<()>) -> tide::Result {
     let Animal { name, legs } = req.body_json().await?;
     Ok(format!("Hello, {}! I've put in an order for {} shoes", name, legs).into())
 }
-// ANCHOR END: example
+// ANCHOR_END: example

--- a/examples/ch03-request-response/src/main.rs
+++ b/examples/ch03-request-response/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> tide::Result<()> {
 
     // ANCHOR: url-params-route
     app.at("/url_params/:some/:parameters").get(url_params);
-    // ANCHOR END: url-params-route
+    // ANCHOR_END: url-params-route
 
     app.at("/query_params").get(query_params);
     app.at("/simple_query").get(simple_query);
@@ -27,7 +27,7 @@ async fn url_params(request: Request<()>) -> tide::Result {
     )
     .into())
 }
-// ANCHOR END: url-params-handler
+// ANCHOR_END: url-params-handler
 
 #[derive(Deserialize)]
 struct Query {

--- a/src/01-introduction/02-example.md
+++ b/src/01-introduction/02-example.md
@@ -3,17 +3,19 @@
 Create an HTTP server that receives a JSON body, validates it, and responds
 with a confirmation message.
 
-```rust
+```rust,edition2018,no_run
 {{#include ../../examples/ch01-02-example/src/main.rs:example}}
 ```
 
 ```sh
 $ curl localhost:8000/orders/shoes -d '{ "name": "Chashu", "legs": 4 }'
 ```
+
 Hello, Chashu! I've put in an order for 4 shoes
 
 ```sh
 $ curl localhost:8000/orders/shoes -d '{ "name": "Mary Millipede", "legs": 750 }'
 ```
+
 number too large to fit in target type
 

--- a/src/02-server_routes_endpoints.md
+++ b/src/02-server_routes_endpoints.md
@@ -45,7 +45,7 @@ async fn main() -> tide::Result<()> {
 
 We use the `at` method to specify the route to the endpoint. We will talk about routes later. For now we'll just use the `"*"` wildcard route that matches anything we throw at it. For this example we will add an async closure as the `Endpoint`. Tide expects something that implements the `Endpoint` trait here. But this closure will work because Tide implements the `Endpoint` trait for certain async functions with a signature that looks like this;
 
-```rust,edition2018,no_run
+```rust,ignore
 async fn endpoint(request: tide::Request) -> tide::Result<impl Into<Response>>
 ```
 
@@ -72,7 +72,7 @@ async fn main() -> tide::Result<()> {
 
 Returning quick string or json results is nice for getting a working endpoint quickly. But for more control a full `Response` struct can be returned.
 
-```rust,edition2018,no_run
+```rust,ignore
 server.at("*").get(|_| async {
     Ok(Response::new(StatusCode::Ok).set_body("Hello world".into()))
 });
@@ -82,7 +82,7 @@ The `Response` type is described in more detail in the next chapter.
 
 More than one endpoint can be added by chaining methods. For example if we want to reply to a `delete` request as wel as a `get` request endpoints can be added for both;
 
-```rust,edition2018,no_run
+```rust,ignore
 server.at("*")
     .get(|_| async { Ok("Hello, world!") })
     .delete(|_| async { Ok("Goodbye, cruel world!") });
@@ -123,12 +123,12 @@ async fn main() -> tide::Result<()> {
 
 Here we added two routes for two different endpoints. Routes can also be composed by chaining the `.at` method.
 
-```rust,edition2018,no_run
+```rust,ignore
 server.at("/hello").at("world").get(|_| async { Ok("Hello, world!") });
 ```
 This will give you the same result as:
 
-```rust,edition2018,no_run
+```rust,ignore
 server.at("/hello/world").get(|_| async { Ok("Hello, world!") });
 ```
 
@@ -176,6 +176,7 @@ fn set_v2_routes(route: Route) {
 This example shows for example an API that exposes two different versions. The routes for each version are defined in a separate function.
 
 ## Wildcards
+
 There are two wildcard characters we can use `:` and `*`. We already met the `*` wildcard. We used it in the first couple of endpoint examples.
 Both wildcard characters will match route segments. Segments are the pieces of a route that are separated with slashes. `:` will match exactly one segment while '*' will match one or more segments.
 
@@ -184,10 +185,12 @@ Both wildcard characters will match route segments. Segments are the pieces of a
 "foo/:/baz" will match "/foo/bar/baz" but not "/foo/bar/qux/baz", the latter has two segments between foo and baz, while `:` only matches single segments.
 
 ### Naming wildcards
+
 It is also possible to name wildcards. This allows you to query the specific strings the wildcard matched on. For example `"/:bar/*baz"` 
 will match the string `"/one/two/three"`. You can then query which wildcards matched which parts of the string. In this case `bar` matched `one` while `baz` matched `two/three`. We'll see how you can use this to parse parameters from urls in the next chapter.
 
 ### Wildcard precedence
+
 When using wildcards it is possible to define multiple different routes that match the same path.
 
 The routes `"/some/*"` and `"/some/specific/*"` will both match the path `"/some/specific/route"` for example. In many web-frameworks the order in which the routes are defined will determine which route will match. Tide will match the most specific route that matches. In the example it the `"/some/specific/*"` route will match the path.

--- a/src/02-server_routes_endpoints.md
+++ b/src/02-server_routes_endpoints.md
@@ -165,11 +165,11 @@ async fn main() -> tide::Result<()> {
     Ok(())
 }
 
-fn v1_routes(route: Route) {
+fn set_v1_routes(route: Route) {
     route.at("version").get(|_| async { Ok("Version one") });
 }
 
-fn v2_routes(route: Route) {
+fn set_v2_routes(route: Route) {
     route.at("version").get(|_| async { Ok("Version two") });
 }
 ```

--- a/src/02-server_routes_endpoints.md
+++ b/src/02-server_routes_endpoints.md
@@ -7,7 +7,8 @@ When a `Server` is started it will handle incoming `Request`s by matching their 
 ## Set up a Server
 
 A basic Tide `Server` is constructed with `tide::new()`.
-```rust
+
+```rust,edition2018,no_run
 #[async_std::main]
 async fn main() -> tide::Result<()> {
     let server = tide::new();
@@ -16,7 +17,8 @@ async fn main() -> tide::Result<()> {
 ```
 
 The server can then be started using the asynchronous `listen` method.
-```rust
+
+```rust,edition2018,no_run
 #[async_std::main]
 async fn main() -> tide::Result<()> {
     let server = tide::new();
@@ -31,7 +33,7 @@ While this is the simpelest Tide application that you can build, it is not very 
 
 To make the `Server` return anything other than an HTTP 404 reply we need to tell it how to react to requests. We do this by adding one or more Endpoints;
 
-```rust
+```rust,edition2018,no_run
 #[async_std::main]
 async fn main() -> tide::Result<()> {
     let mut server = tide::new();
@@ -42,13 +44,14 @@ async fn main() -> tide::Result<()> {
 ```
 
 We use the `at` method to specify the route to the endpoint. We will talk about routes later. For now we'll just use the `"*"` wildcard route that matches anything we throw at it. For this example we will add an async closure as the `Endpoint`. Tide expects something that implements the `Endpoint` trait here. But this closure will work because Tide implements the `Endpoint` trait for certain async functions with a signature that looks like this;
-```rust
+
+```rust,edition2018,no_run
 async fn endpoint(request: tide::Request) -> tide::Result<impl Into<Response>>
 ```
 
 In this case `Into<Response>` is implemented for `&str` so our closure is a valid Endpoint. Because `Into<Response>` is implemented for several other types you can quickly set up endpoints. For example the next endpoint uses the `json!` macro provided by `use tide::prelude::*` to return a `serde_json::Value`.
 
-```rust
+```rust,edition2018,no_run
 use tide::prelude::*;
 #[async_std::main]
 async fn main() -> tide::Result<()> {
@@ -69,7 +72,7 @@ async fn main() -> tide::Result<()> {
 
 Returning quick string or json results is nice for getting a working endpoint quickly. But for more control a full `Response` struct can be returned.
 
-```rust
+```rust,edition2018,no_run
 server.at("*").get(|_| async {
     Ok(Response::new(StatusCode::Ok).set_body("Hello world".into()))
 });
@@ -79,7 +82,7 @@ The `Response` type is described in more detail in the next chapter.
 
 More than one endpoint can be added by chaining methods. For example if we want to reply to a `delete` request as wel as a `get` request endpoints can be added for both;
 
-```rust
+```rust,edition2018,no_run
 server.at("*")
     .get(|_| async { Ok("Hello, world!") })
     .delete(|_| async { Ok("Goodbye, cruel world!") });
@@ -87,7 +90,7 @@ server.at("*")
 
 Eventually, especially when our endpoint methods grow a bit, the route definitions will get a crowded. We could move our endpoint implementations to their own functions;
 
-```rust
+```rust,edition2018,no_run
 #[async_std::main]
 async fn main() -> tide::Result<()> {
     let mut server = tide::new();
@@ -105,7 +108,7 @@ async fn endpoint(_req: tide::Request<()>) -> Result<Response> {
 
 The server we built is still not very useful. It will return the same response for any URL. It is only able to differentiate between requests by HTTP method. We already used the `.at` method of the `Server` to define a wildcard route. You might have guessed how to add endpoints to specific routes;
 
-```rust,ignore
+```rust,edition2018,no_run
 #[async_std::main]
 async fn main() -> tide::Result<()> {
     let mut server = tide::new();
@@ -119,16 +122,19 @@ async fn main() -> tide::Result<()> {
 ```
 
 Here we added two routes for two different endpoints. Routes can also be composed by chaining the `.at` method.
-```rust
+
+```rust,edition2018,no_run
 server.at("/hello").at("world").get(|_| async { Ok("Hello, world!") });
 ```
 This will give you the same result as:
-```rust
+
+```rust,edition2018,no_run
 server.at("/hello/world").get(|_| async { Ok("Hello, world!") });
 ```
 
 We can store the partial routes and re-use them;
-```rust
+
+```rust,edition2018,no_run
 #[async_std::main]
 async fn main() -> tide::Result<()> {
     let mut server = tide::new();
@@ -146,7 +152,8 @@ async fn main() -> tide::Result<()> {
 Here we added two sub-routes to the `hello` route. One at `/hello/world` and another one at `hello/mum` with different endpoint functions. We also added an endpoint at `/hello`. This gives an idea what it will be like to build up more complex routing trees
 
 When you have a complex api this also allows you to define different pieces of your route tree in separate functions.
-```rust
+
+```rust,edition2018,no_run
 #[async_std::main]
 async fn main() -> tide::Result<()> {
     let mut server = tide::new();

--- a/src/03-request-response.md
+++ b/src/03-request-response.md
@@ -1,7 +1,7 @@
 # Request and Response
 
 In the previous chapter we saw how endpoints are functions that take a `Request` and return a `Response`, or more accurately a `Result` enum with a type that can be turned into a `Response`
-```rust
+```rust,edition2018,no_run
 async fn endpoint(request: tide::Request) -> tide::Result<impl Into<Response>>
 ```
 The `Request` object contains all the information from the HTTP request that was received by the server. The URL from the request, HTTP headers, cookies and query string parameters can all be found in the `Request`.
@@ -16,12 +16,16 @@ The Tide `Request` struct is te input to your endpoint handler function. It cont
 
 ### Accessing Url parameters
 In the last chapter where we talked about matching Url routes and specifically in the paragraph about wildcards we already mentioned Url-parameters.
+
 From any route with named wildcards like this;
-```rust
+
+```rust,edition2018,no_run
 {{#include ../examples/ch03-request-response/src/main.rs:url-params-route}}
 ```
+
 Any value that was used to match the a wildcard can be retrieved using the `request.param` method;
-```rust
+
+```rust,edition2018,no_run
 {{#include ../examples/ch03-request-response/src/main.rs:url-params-handler}}
 ```
 

--- a/src/03-request-response.md
+++ b/src/03-request-response.md
@@ -19,13 +19,13 @@ In the last chapter where we talked about matching Url routes and specifically i
 
 From any route with named wildcards like this;
 
-```rust,edition2018,no_run
+```rust,ignore
 {{#include ../examples/ch03-request-response/src/main.rs:url-params-route}}
 ```
 
 Any value that was used to match the a wildcard can be retrieved using the `request.param` method;
 
-```rust,edition2018,no_run
+```rust,ignore
 {{#include ../examples/ch03-request-response/src/main.rs:url-params-handler}}
 ```
 


### PR DESCRIPTION
- Correct `ANCHOR END` to `ANCHOR_END`.
- Correct function name v1_routes/v2_routes to set_v1_routes/set_v2_routes which be called in `main` function.
- Add `edition2018,no_run` for Rust code, avoid errors occurred while clicking `run` button.
- Add Tide chinese book, I will update from the official documents synchronously.